### PR TITLE
Add NULL sentinel as last argument to execl.

### DIFF
--- a/Superuser/jni/su/su.c
+++ b/Superuser/jni/su/su.c
@@ -71,7 +71,7 @@ void exec_log(char *priority, char* logline) {
       int null = open("/dev/null", O_WRONLY | O_CLOEXEC);
       dup2(null, 1);
       dup2(null, 2);
-      execl("/system/bin/log", "/system/bin/log", "-p", priority, "-t", LOG_TAG, logline);
+      execl("/system/bin/log", "/system/bin/log", "-p", priority, "-t", LOG_TAG, logline, (char *)NULL);
       _exit(0);
   }
 }


### PR DESCRIPTION
execl expects the list of arguments to be terminated by a NULL pointer.
